### PR TITLE
[logscrapper]: Modify query to support label is_audit=true

### DIFF
--- a/charts/values.prod.yaml
+++ b/charts/values.prod.yaml
@@ -15,7 +15,7 @@ gpgRecipient: "s3logs@giosg.com"
 instances:
   auditd:
     cronSchedule: "0 1 * * *"
-    logcliQuery: '{is_audit=~"is_audit|true"}'
+    logcliQuery: '{is_audit="true"}'
     startTime: "yesterday 00:00:00"
     endTime: "today 00:00:00"
 


### PR DESCRIPTION
```
helm diff -n loki logscrapper logscrapper/ -f values.prod.yaml -f secrets.prod.yaml.dec --show-secrets
Command "helm diff" is deprecated, use "helm diff upgrade" instead
loki, logscrapper-auditd, CronJob (batch) has changed:
  # Source: logscrapper/templates/cronjob.yaml
  apiVersion: batch/v1
  kind: CronJob
  metadata:
    name: logscrapper-auditd
    labels:
      helm.sh/chart: logscrapper-0.1.0
      app.kubernetes.io/name: logscrapper
      app.kubernetes.io/instance: logscrapper
      app.kubernetes.io/managed-by: Helm
      app.kubernetes.io/component: auditd
  spec:
    schedule: 0 1 * * *
    concurrencyPolicy: Forbid
    jobTemplate:
      spec:
        template:
          metadata:
            labels:
              app.kubernetes.io/name: logscrapper
              app.kubernetes.io/instance: logscrapper
              app.kubernetes.io/component: auditd
          spec:
            imagePullSecrets:
            - name: giosg.hub.docker.com
            volumes:
            - name: gpg
              secret:
                secretName: logscrapper-gpg
            - name: cache
              emptyDir: {}
            containers:
            - name: logscrapper
              image: giosg/logscrapper:2.2
              imagePullPolicy: IfNotPresent
              resources:
                limits:
                  cpu: 4
                  memory: 6Gi
                requests:
                  cpu: 1
                  memory: 2Gi
              env:
           
              - name: AWS_ACCESS_KEY_ID
                valueFrom:
                  secretKeyRef:
                    name: logscrapper
                    key: awsAccessKeyId
              - name: AWS_SECRET_ACCESS_KEY
                valueFrom:
                  secretKeyRef:
                    name: logscrapper
                    key: awsSecretAccessKey
              - name: AWS_DEFAULT_REGION
                value: "eu-west-1"
              - name: PART_PATH_PREFIX
                value: "/cache"
-             args: ['{is_audit=~"is_audit|true"}']
+             args: ['{is_audit="true"}']
              volumeMounts:
              - name: gpg
                readOnly: true
                mountPath: "/etc/gpg"
              - mountPath: /cache
                name: cache
            restartPolicy: Never